### PR TITLE
Fix/connection shared

### DIFF
--- a/src/Factory/Connection.php
+++ b/src/Factory/Connection.php
@@ -84,27 +84,25 @@ final readonly class Connection implements FactoryInterface
 
         $repository = new SQL\Factory\Repository\Connection($connection);
 
-        if (\array_key_exists('shared', $config) && true === $config['shared']) {
-            $repository->addFiles(new File('PDOPool.php', new InMemory(<<<PHP
-                <?php
+        $repository->addFiles(new File('PDOPool.php', new InMemory(<<<PHP
+            <?php
 
-                namespace {$this->generatedNamespace};
-                final class PDOPool {
-                    private static array \$connections = [];
-                    public static function unique(string \$dsn, ?string \$username = null, ?string \$password = null, \$options = []): \\PDO {
-                        return new \\PDO(\$dsn, \$username, \$password, \$options);
-                    }
-                    public static function shared(string \$dsn, ?string \$username = null, ?string \$password = null, \$options = []): \\PDO {
-                        if (isset(self::\$connections[\$dsn])) {
-                            return self::\$connections[\$dsn];
-                        }
-                        
-                        return self::\$connections[\$dsn] = self::unique(\$dsn, \$username, \$password, \$options);
-                    }
+            namespace {$this->generatedNamespace};
+            final class PDOPool {
+                private static array \$connections = [];
+                public static function unique(string \$dsn, ?string \$username = null, ?string \$password = null, \$options = []): \\PDO {
+                    return new \\PDO(\$dsn, \$username, \$password, \$options);
                 }
-                PHP
-            )));
-        }
+                public static function shared(string \$dsn, ?string \$username = null, ?string \$password = null, \$options = []): \\PDO {
+                    if (isset(self::\$connections[\$dsn])) {
+                        return self::\$connections[\$dsn];
+                    }
+                    
+                    return self::\$connections[\$dsn] = self::unique(\$dsn, \$username, \$password, \$options);
+                }
+            }
+            PHP
+        )));
 
         return $repository;
     }


### PR DESCRIPTION
always create PDOPool.php, because it is used both in "shared" and "unique" connections (as seen in src/Builder/Connection):

![Capture d’écran 2023-05-18 à 14 11 37](https://github.com/php-etl/sql-plugin/assets/28787740/2addb301-f8d9-48cc-bc00-c1b47c0792eb)

https://github.com/php-etl/sql-plugin/issues/21