### PR TITLE
lookup check result exists

### DIFF
--- a/src/Builder/AlternativeLookup.php
+++ b/src/Builder/AlternativeLookup.php
@@ -120,7 +120,14 @@ final class AlternativeLookup implements StepBuilderInterface
                 ...array_filter(
                     [
                         $this->getAlternativeLookupNode(),
-                        $this->merge?->getNode(),
+                        new Node\Stmt\If_(
+                            cond: new Node\Expr\Variable('lookup'),
+                            subNodes: [
+                                'stmts' => [
+                                    $this->merge?->getNode(),
+                                ],
+                            ]
+                        ),
                         new Node\Stmt\Return_(
                             new Node\Expr\Variable('output')
                         ),

--- a/src/Builder/ConditionalLookup.php
+++ b/src/Builder/ConditionalLookup.php
@@ -7,7 +7,6 @@ namespace Kiboko\Plugin\SQL\Builder;
 use Kiboko\Contract\Configurator\StepBuilderInterface;
 use Kiboko\Contract\Mapping\CompiledMapperInterface;
 use PhpParser\Node;
-use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 final class ConditionalLookup implements StepBuilderInterface
@@ -188,7 +187,8 @@ final class ConditionalLookup implements StepBuilderInterface
                                                     default: new Node\Expr\ConstFetch(
                                                         name: new Node\Name(name: 'null'),
                                                     ),
-                                                    type: new Node\Name\FullyQualified(LoggerInterface::class)
+                                                    type: new Node\NullableType(\Psr\Log\LoggerInterface::class),
+                                                    flags: Node\Stmt\Class_::MODIFIER_PRIVATE
                                                 ),
                                             ],
                                         ],


### PR DESCRIPTION
SQL lookup may return false. in that case, dont try to merge this result with the line.

avant:
![image](https://github.com/php-etl/sql-plugin/assets/28787740/71d782a6-fd02-4cd7-b443-f732b8686a59)

après:

![image](https://github.com/php-etl/sql-plugin/assets/28787740/11de21a5-ed42-4bd7-abf3-33a47f9a8745)
